### PR TITLE
Silence rm error when files are missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ hashtable.o : hashtable.c hashtable.h
 	$(CC) $(CFLAGS) hashtable.c
 
 clean :
-	rm *.o
-	rm philspel
+	rm -f *.o philspel
 
 test : clean philspel
 	touch testOutput


### PR DESCRIPTION
If students are missing compiler output files, cleanup should not
error since there is nothing to error on